### PR TITLE
feat: multi-genre distribute + hierarchy + drop warning

### DIFF
--- a/app/bot/__init__.py
+++ b/app/bot/__init__.py
@@ -167,9 +167,39 @@ async def setup_bot(pool):
         except Exception as e:
             log.debug(f"Failed to send fuzzy confirm to {target}: {e}")
 
+    async def on_drop_warn(telegram_id, track_title, artist, drops, playlist_name, track_id, playlist_spotify_id):
+        """Warn that a track was previously dropped."""
+        from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+        track_fmt = format_track(track_title, artist, track_id)
+        drop_lines = [f"  ❌ {d['playlist']} ({d['date']}) — добавил {d['added_by']}" for d in drops]
+        drop_text = "\n".join(drop_lines)
+
+        msg = (
+            f"⚠️ <b>Ранее дропнутый трек!</b>\n\n"
+            f"🎵 {track_fmt}\nДобавлен в <b>{playlist_name}</b>\n\n"
+            f"Был дропнут:\n{drop_text}\n\n"
+            f"Оставить или убрать?"
+        )
+
+        kb = InlineKeyboardMarkup(inline_keyboard=[[
+            InlineKeyboardButton(text="✅ Оставить", callback_data=f"keep_dup:{track_id}"),
+            InlineKeyboardButton(text="🗑 Убрать", callback_data=f"confirm_dup:{playlist_spotify_id}:{track_id}"),
+        ]])
+
+        target = telegram_id or settings.telegram_admin_id
+        try:
+            await send(target, msg, reply_markup=kb)
+        except Exception as e:
+            log.debug(f"Failed to send drop warning to {target}: {e}")
+
     set_duplicate_notify(on_duplicate_found)
     set_fuzzy_confirm(on_fuzzy_duplicate_confirm)
-    watcher = DuplicateWatcher(pool, on_duplicate_found, confirm_callback=on_fuzzy_duplicate_confirm)
+    watcher = DuplicateWatcher(
+        pool, on_duplicate_found,
+        confirm_callback=on_fuzzy_duplicate_confirm,
+        drop_warn_callback=on_drop_warn,
+    )
     asyncio.create_task(watcher.start())
 
     init_health()

--- a/app/bot/commands/admin.py
+++ b/app/bot/commands/admin.py
@@ -650,13 +650,24 @@ async def on_dbinfo(message: Message):
 @router.message(Command("backfill_genres"))
 @require_admin
 async def on_backfill_genres(message: Message):
-    await message.answer("⏳ Запускаю бэкфилл жанров...")
+    args = message.text.split(maxsplit=1)
+    reset = len(args) > 1 and args[1].strip().lower() == "reset"
+
+    if reset:
+        async with get_pool().acquire() as conn:
+            await conn.execute("UPDATE playlist_tracks SET genre = NULL")
+        await message.answer("🔄 Все жанры сброшены. Запускаю бэкфилл через Last.fm + AI...\n\n⚠️ Если бэкфилл прервётся — запусти /backfill_genres повторно.")
+    else:
+        await message.answer("⏳ Запускаю бэкфилл жанров (только пустые)...")
+
     try:
         result = await backfill_genres(get_pool())
-        await message.answer(
+        await reply(
+            message,
             f"✅ Бэкфилл готов!\n"
             f"Обработано: {result['processed']}\n"
-            f"Жанры найдены: {result['resolved']}"
+            f"Жанры найдены: {result['resolved']}\n"
+            f"Не определено: {result['unknown']}",
         )
     except Exception as e:
         log.error(f"Genre backfill failed: {e}")

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
 
     # Last.fm
     lastfm_api_key: str = ""
+    lastfm_shared_secret: str = ""
 
     # Voting
     vote_drop_threshold: int = 2

--- a/app/services/duplicate_watcher.py
+++ b/app/services/duplicate_watcher.py
@@ -8,16 +8,18 @@ from app.spotify.auth import get_spotify
 from app.services.playlists import check_duplicate, get_track_isrc
 from app.services.ai import generate_track_facts
 from app.services.genre_resolver import resolve_and_save_genre
+from app.services.genre_distributor import check_previously_dropped
 from app.services.normalize import normalize_title, normalize_artist
 
 log = logging.getLogger(__name__)
 
 
 class DuplicateWatcher:
-    def __init__(self, pool: asyncpg.Pool, notify_callback, confirm_callback=None):
+    def __init__(self, pool: asyncpg.Pool, notify_callback, confirm_callback=None, drop_warn_callback=None):
         self._pool = pool
-        self._notify = notify_callback  # async fn(telegram_id, track_title, artist, duplicates, playlist_name, track_id)
-        self._confirm = confirm_callback  # async fn(telegram_id, track_title, artist, duplicates, playlist_name, track_id, playlist_spotify_id) — for fuzzy matches
+        self._notify = notify_callback
+        self._confirm = confirm_callback
+        self._drop_warn = drop_warn_callback
         self._running = False
 
     async def start(self):
@@ -231,6 +233,28 @@ class DuplicateWatcher:
                             track_title=track.name,
                             artist=track_artist,
                             duplicates=fuzzy_only,
+                            playlist_name=pl["name"],
+                            track_id=track.id,
+                            playlist_spotify_id=playlist_spotify_id,
+                        )
+
+                # Check if track was previously dropped
+                if not duplicates:
+                    drops = await check_previously_dropped(self._pool, track.id)
+                    if drops and self._drop_warn:
+                        telegram_id = None
+                        if added_by:
+                            async with self._pool.acquire() as conn:
+                                row = await conn.fetchrow(
+                                    "SELECT telegram_id FROM users WHERE spotify_id = $1", added_by
+                                )
+                                if row:
+                                    telegram_id = row["telegram_id"]
+                        await self._drop_warn(
+                            telegram_id=telegram_id,
+                            track_title=track.name,
+                            artist=track_artist,
+                            drops=drops,
                             playlist_name=pl["name"],
                             track_id=track.id,
                             playlist_spotify_id=playlist_spotify_id,

--- a/app/services/genre_distributor.py
+++ b/app/services/genre_distributor.py
@@ -24,21 +24,39 @@ GENRE_MAP = {
     "TURDOM Phonk": ["phonk"],
 }
 
+# Hierarchy: specific genre suppresses its parent.
+# If a track matches Metal, don't also add to Rock.
+_GENRE_HIERARCHY = {
+    "TURDOM Metal": {"TURDOM Rock"},       # metal suppresses rock
+    "TURDOM DnB": {"TURDOM Electronic"},   # dnb suppresses electronic
+    "TURDOM R&B": {"TURDOM Pop"},           # r&b suppresses pop
+}
+
 
 def classify_track(genre_str: str) -> str | None:
-    """Classify a track's genre string into a genre playlist name.
+    """Classify a track's genre string into a single best genre playlist name.
 
-    Matches by whole words: keyword must appear as complete word(s) in the genre.
-    Longer keyword matches take priority to avoid ambiguity
-    (e.g. 'hardcore hip hop' → Hip-Hop via 'hip hop' (2 words) over 'hardcore' (1 word)).
+    Kept for backward compatibility (stats, tests).
+    """
+    results = classify_track_multi(genre_str)
+    return results[0] if results else None
+
+
+def classify_track_multi(genre_str: str) -> list[str]:
+    """Classify a track's genre string into ALL matching genre playlists.
+
+    Applies hierarchy rules: Metal suppresses Rock, DnB suppresses Electronic, etc.
+    Returns deduplicated list of TURDOM playlist names.
     """
     genres = [g.strip().lower() for g in genre_str.split(", ")]
 
-    best_playlist = None
-    best_kw_words = 0
+    matched: set[str] = set()
 
     for genre in genres:
         genre_words = set(genre.split())
+        best_playlist = None
+        best_kw_words = 0
+
         for playlist_name, keywords in GENRE_MAP.items():
             for kw in keywords:
                 kw_words = kw.split()
@@ -46,7 +64,22 @@ def classify_track(genre_str: str) -> str | None:
                     best_kw_words = len(kw_words)
                     best_playlist = playlist_name
 
-    return best_playlist
+        if best_playlist:
+            matched.add(best_playlist)
+
+    # Apply hierarchy: remove suppressed genres
+    # Each individual tag maps to exactly one playlist (longest keyword match wins)
+    suppressed = set()
+    for specific, parents in _GENRE_HIERARCHY.items():
+        if specific in matched:
+            suppressed |= parents
+
+    result = [p for p in matched if p not in suppressed]
+
+    if matched and not result:
+        log.warning(f"All genres suppressed for tags: {genre_str} (matched: {matched})")
+
+    return sorted(result)
 
 
 async def load_genre_playlist_ids(pool: asyncpg.Pool):
@@ -71,7 +104,10 @@ async def load_genre_playlist_ids(pool: asyncpg.Pool):
 
 
 async def distribute_session_tracks(pool: asyncpg.Pool, session_id: int):
-    """Distribute kept tracks from a finished session to genre playlists."""
+    """Distribute kept tracks from a finished session to genre playlists.
+
+    Uses classify_track_multi — a track can go to multiple playlists.
+    """
     if not _genre_playlist_ids:
         await load_genre_playlist_ids(pool)
 
@@ -91,16 +127,18 @@ async def distribute_session_tracks(pool: asyncpg.Pool, session_id: int):
             AND pt.genre IS NOT NULL AND pt.genre != 'unknown'
         """, session_id)
 
-    # Group by genre playlist
+    # Group by genre playlist (multi-genre: one track → multiple playlists)
     to_add: dict[str, list[str]] = {}
     skipped = 0
 
     for track in tracks:
-        genre_playlist = classify_track(track["genre"])
-        if genre_playlist and genre_playlist in _genre_playlist_ids:
-            if genre_playlist not in to_add:
-                to_add[genre_playlist] = []
-            to_add[genre_playlist].append(track["spotify_track_id"])
+        playlists = classify_track_multi(track["genre"])
+        if playlists:
+            for pl_name in playlists:
+                if pl_name in _genre_playlist_ids:
+                    if pl_name not in to_add:
+                        to_add[pl_name] = []
+                    to_add[pl_name].append(track["spotify_track_id"])
         else:
             skipped += 1
 
@@ -135,3 +173,26 @@ async def distribute_session_tracks(pool: asyncpg.Pool, session_id: int):
 
     log.info(f"Distribution done: {distributed} distributed, {skipped} skipped")
     return {"distributed": distributed, "skipped": skipped}
+
+
+async def check_previously_dropped(pool: asyncpg.Pool, spotify_track_id: str) -> list[dict] | None:
+    """Check if a track was previously dropped in any session.
+
+    Returns list of sessions where it was dropped, or None if never dropped.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch("""
+            SELECT DISTINCT s.playlist_name, s.started_at,
+                   COALESCE('@' || NULLIF(u.telegram_username, ''), u.telegram_name, '?') as added_by
+            FROM session_tracks st
+            JOIN sessions s ON st.session_id = s.id
+            LEFT JOIN users u ON st.added_by_spotify_id = u.spotify_id
+            WHERE st.spotify_track_id = $1 AND st.vote_result = 'drop'
+        """, spotify_track_id)
+
+    if not rows:
+        return None
+
+    return [{"playlist": r["playlist_name"],
+             "date": r["started_at"].strftime("%d/%m/%Y") if r["started_at"] else "?",
+             "added_by": r["added_by"]} for r in rows]

--- a/app/services/genre_resolver.py
+++ b/app/services/genre_resolver.py
@@ -1,9 +1,11 @@
-"""Resolve genre for a track via Last.fm tags, AI classification, or Spotify artist genres.
+"""Resolve genre for a track via Last.fm tags or AI classification.
 
 Priority chain:
 1. Last.fm track.getTopTags — most accurate (track-level, user-contributed)
 2. AI classification — GPT classifies by track name + artist into TURDOM genres
-3. Spotify artist genres — fallback (artist-level, often inaccurate for multi-genre artists)
+3. No fallback — returns None (admin handles manually)
+
+Spotify artist genres removed — too inaccurate for track-level classification.
 """
 import asyncio
 import logging
@@ -21,16 +23,16 @@ log = logging.getLogger(__name__)
 _GENRE_NAMES = [name.replace("TURDOM ", "") for name in GENRE_MAP.keys()]
 
 
-async def resolve_genre(track) -> str:
+async def resolve_genre(track) -> str | None:
     """Resolve genre string for a Spotify track object.
 
-    Tries: Last.fm → AI → Spotify artist genres.
-    Returns comma-separated genre string, or 'unknown'.
+    Tries: Last.fm → AI. Returns comma-separated genre tags, or None.
+    Stores up to 5 classifiable tags for multi-genre distribution.
     """
     title = track.name
     artist = ", ".join(a.name for a in track.artists) if track.artists else ""
 
-    # 1. Last.fm
+    # 1. Last.fm — returns multiple tags
     genre = await _resolve_lastfm(title, artist)
     if genre:
         log.debug(f"Genre via Last.fm for '{title}': {genre}")
@@ -42,32 +44,27 @@ async def resolve_genre(track) -> str:
         log.debug(f"Genre via AI for '{title}': {genre}")
         return genre
 
-    # 3. Spotify artist genres (fallback)
-    genre = await _resolve_spotify(track)
-    if genre:
-        log.debug(f"Genre via Spotify for '{title}': {genre}")
-        return genre
-
-    return "unknown"
+    # 3. No fallback — return None for manual handling
+    log.debug(f"No genre found for '{title}' by '{artist}'")
+    return None
 
 
 async def _resolve_lastfm(title: str, artist: str) -> str | None:
-    """Try Last.fm track tags. Returns genre string if classifiable."""
+    """Try Last.fm track tags. Returns up to 5 classifiable tags as comma-separated string."""
     tags = await get_track_tags(title, artist)
     if not tags:
         return None
 
-    # Try to classify each tag through GENRE_MAP
+    # Collect all tags that map to a TURDOM playlist (up to 5)
+    classifiable = []
     for tag in tags:
-        classified = classify_track(tag)
-        if classified:
-            return tag  # Return raw tag — classify_track() maps it in distribute
+        if classify_track(tag) and tag not in classifiable:
+            classifiable.append(tag)
+            if len(classifiable) >= 5:
+                break
 
-    # If no single tag matches, try comma-joined
-    joined = ", ".join(tags[:5])
-    classified = classify_track(joined)
-    if classified:
-        return joined
+    if classifiable:
+        return ", ".join(classifiable)
 
     return None
 
@@ -89,24 +86,22 @@ async def _resolve_ai(title: str, artist: str) -> str | None:
                 "role": "user",
                 "content": (
                     f"Определи жанр трека '{title}' исполнителя '{artist}'. "
-                    f"Выбери ОДИН из: {genres_list}. "
-                    f"Ответь только названием жанра, одним словом или фразой. "
+                    f"Выбери ОДИН или НЕСКОЛЬКО из: {genres_list}. "
+                    f"Ответь только названиями жанров через запятую. "
                     f"Если не знаешь — ответь 'unknown'."
                 ),
             }],
-            max_tokens=20,
+            max_tokens=50,
             temperature=0,
         )
 
         result = resp.choices[0].message.content.strip().lower()
         if result and result != "unknown":
-            # Verify it maps to a TURDOM playlist
-            for genre_name in _GENRE_NAMES:
-                if genre_name.lower() == result:
-                    return result
-            # Try classify_track as fallback
-            if classify_track(result):
-                return result
+            # Verify each part maps to a TURDOM playlist
+            parts = [p.strip() for p in result.split(",")]
+            valid = [p for p in parts if classify_track(p)]
+            if valid:
+                return ", ".join(valid)
 
         return None
     except Exception as e:
@@ -114,50 +109,30 @@ async def _resolve_ai(title: str, artist: str) -> str | None:
         return None
 
 
-async def _resolve_spotify(track) -> str | None:
-    """Fallback: Spotify artist genres."""
-    if not track.artists:
-        return None
-
-    sp = await get_spotify()
-
-    for artist_ref in track.artists:
-        try:
-            artist = await sp.artist(artist_ref.id)
-            genres = artist.genres or []
-            if genres:
-                return ", ".join(genres)
-        except Exception as e:
-            log.warning(f"Failed to fetch artist {artist_ref.id} for genre: {e}")
-
-    return None
-
-
-async def resolve_and_save_genre(pool: asyncpg.Pool, track) -> str:
+async def resolve_and_save_genre(pool: asyncpg.Pool, track) -> str | None:
     """Resolve genre and save it to all playlist_tracks rows for this track."""
     genre = await resolve_genre(track)
 
-    async with pool.acquire() as conn:
-        await conn.execute(
-            "UPDATE playlist_tracks SET genre = $1 WHERE spotify_track_id = $2 AND (genre IS NULL OR genre = 'unknown')",
-            genre, track.id,
-        )
-
-    if genre != "unknown":
+    if genre:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE playlist_tracks SET genre = $1 WHERE spotify_track_id = $2 AND (genre IS NULL)",
+                genre, track.id,
+            )
         log.debug(f"Genre for '{track.name}': {genre}")
 
     return genre
 
 
 async def backfill_genres(pool: asyncpg.Pool) -> dict:
-    """Backfill genres for all tracks missing them. Returns stats."""
+    """Backfill genres for all tracks. Resets and re-resolves via Last.fm + AI."""
     async with pool.acquire() as conn:
         tracks = await conn.fetch(
-            "SELECT DISTINCT spotify_track_id FROM playlist_tracks WHERE genre IS NULL OR genre = 'unknown'"
+            "SELECT DISTINCT spotify_track_id FROM playlist_tracks WHERE genre IS NULL"
         )
 
     if not tracks:
-        return {"processed": 0, "resolved": 0}
+        return {"processed": 0, "resolved": 0, "unknown": 0}
 
     sp = await get_spotify()
     processed = 0
@@ -170,20 +145,19 @@ async def backfill_genres(pool: asyncpg.Pool) -> dict:
                 track = await sp.track(track_id)
                 genre = await resolve_genre(track)
 
-                await conn.execute(
-                    "UPDATE playlist_tracks SET genre = $1 WHERE spotify_track_id = $2",
-                    genre, track_id,
-                )
-
-                processed += 1
-                if genre != "unknown":
+                if genre:
+                    await conn.execute(
+                        "UPDATE playlist_tracks SET genre = $1 WHERE spotify_track_id = $2",
+                        genre, track_id,
+                    )
                     resolved += 1
 
-                # Rate limit: avoid hammering Last.fm/OpenAI/Spotify
+                processed += 1
                 await asyncio.sleep(0.25)
             except Exception as e:
                 log.warning(f"Failed to backfill genre for {track_id}: {e}")
                 processed += 1
 
-    log.info(f"Genre backfill done: {processed} processed, {resolved} resolved")
-    return {"processed": processed, "resolved": resolved}
+    unknown = processed - resolved
+    log.info(f"Genre backfill done: {processed} processed, {resolved} resolved, {unknown} unknown")
+    return {"processed": processed, "resolved": resolved, "unknown": unknown}

--- a/tests/test_lastfm_genre.py
+++ b/tests/test_lastfm_genre.py
@@ -121,11 +121,10 @@ class TestLastfmClient:
 
 class TestGenreResolutionChain:
 
-    @patch("app.services.genre_resolver._resolve_spotify", new_callable=AsyncMock, return_value=None)
     @patch("app.services.genre_resolver._resolve_ai", new_callable=AsyncMock, return_value=None)
     @patch("app.services.genre_resolver._resolve_lastfm", new_callable=AsyncMock, return_value="rock")
-    def test_lastfm_wins(self, mock_lastfm, mock_ai, mock_spotify):
-        """Last.fm result should be used, AI and Spotify not called."""
+    def test_lastfm_wins(self, mock_lastfm, mock_ai):
+        """Last.fm result should be used, AI not called."""
         from app.services.genre_resolver import resolve_genre
 
         track = MagicMock()
@@ -137,12 +136,10 @@ class TestGenreResolutionChain:
         result = run(resolve_genre(track))
         assert result == "rock"
         mock_ai.assert_not_called()
-        mock_spotify.assert_not_called()
 
-    @patch("app.services.genre_resolver._resolve_spotify", new_callable=AsyncMock, return_value=None)
     @patch("app.services.genre_resolver._resolve_ai", new_callable=AsyncMock, return_value="metal")
     @patch("app.services.genre_resolver._resolve_lastfm", new_callable=AsyncMock, return_value=None)
-    def test_ai_fallback(self, mock_lastfm, mock_ai, mock_spotify):
+    def test_ai_fallback(self, mock_lastfm, mock_ai):
         """If Last.fm fails, AI should be used."""
         from app.services.genre_resolver import resolve_genre
 
@@ -154,13 +151,11 @@ class TestGenreResolutionChain:
 
         result = run(resolve_genre(track))
         assert result == "metal"
-        mock_spotify.assert_not_called()
 
-    @patch("app.services.genre_resolver._resolve_spotify", new_callable=AsyncMock, return_value="indie rock, alternative")
     @patch("app.services.genre_resolver._resolve_ai", new_callable=AsyncMock, return_value=None)
     @patch("app.services.genre_resolver._resolve_lastfm", new_callable=AsyncMock, return_value=None)
-    def test_spotify_last_resort(self, mock_lastfm, mock_ai, mock_spotify):
-        """If Last.fm and AI both fail, Spotify artist genres used."""
+    def test_all_fail_returns_none(self, mock_lastfm, mock_ai):
+        """If Last.fm and AI both fail, return None (no Spotify fallback)."""
         from app.services.genre_resolver import resolve_genre
 
         track = MagicMock()
@@ -170,20 +165,4 @@ class TestGenreResolutionChain:
         track.artists = [artist_mock]
 
         result = run(resolve_genre(track))
-        assert result == "indie rock, alternative"
-
-    @patch("app.services.genre_resolver._resolve_spotify", new_callable=AsyncMock, return_value=None)
-    @patch("app.services.genre_resolver._resolve_ai", new_callable=AsyncMock, return_value=None)
-    @patch("app.services.genre_resolver._resolve_lastfm", new_callable=AsyncMock, return_value=None)
-    def test_all_fail_returns_unknown(self, mock_lastfm, mock_ai, mock_spotify):
-        """If everything fails, return 'unknown'."""
-        from app.services.genre_resolver import resolve_genre
-
-        track = MagicMock()
-        track.name = "Song"
-        artist_mock = MagicMock()
-        artist_mock.name = "Artist"
-        track.artists = [artist_mock]
-
-        result = run(resolve_genre(track))
-        assert result == "unknown"
+        assert result is None

--- a/tests/test_multi_genre.py
+++ b/tests/test_multi_genre.py
@@ -1,0 +1,157 @@
+"""Tests for multi-genre classification and hierarchy."""
+
+from app.services.genre_distributor import classify_track, classify_track_multi
+
+
+# ============================================================
+# classify_track_multi — returns all matching playlists
+# ============================================================
+
+class TestClassifyTrackMulti:
+
+    def test_single_genre(self):
+        assert classify_track_multi("rock") == ["TURDOM Rock"]
+
+    def test_multiple_independent_genres(self):
+        """Electronic + Hip-Hop → both playlists."""
+        result = classify_track_multi("electronic, hip hop")
+        assert "TURDOM Electronic" in result
+        assert "TURDOM Hip-Hop" in result
+
+    def test_metal_suppresses_rock(self):
+        """Metal > Rock: track goes to Metal only, not Rock."""
+        result = classify_track_multi("metal, rock")
+        assert "TURDOM Metal" in result
+        assert "TURDOM Rock" not in result
+
+    def test_metalcore_suppresses_rock(self):
+        """metalcore maps to Metal, which suppresses Rock."""
+        result = classify_track_multi("metalcore, rock")
+        assert "TURDOM Metal" in result
+        assert "TURDOM Rock" not in result
+
+    def test_dnb_suppresses_electronic(self):
+        """DnB > Electronic."""
+        result = classify_track_multi("drum and bass, electronic")
+        assert "TURDOM DnB" in result
+        assert "TURDOM Electronic" not in result
+
+    def test_rnb_suppresses_pop(self):
+        """R&B > Pop."""
+        result = classify_track_multi("r&b, pop")
+        assert "TURDOM R&B" in result
+        assert "TURDOM Pop" not in result
+
+    def test_rock_only_no_suppression(self):
+        """Rock without Metal → goes to Rock."""
+        result = classify_track_multi("rock, grunge")
+        assert result == ["TURDOM Rock"]
+
+    def test_electronic_only_no_suppression(self):
+        """Electronic without DnB → goes to Electronic."""
+        result = classify_track_multi("techno, house")
+        assert result == ["TURDOM Electronic"]
+
+    def test_three_independent_genres(self):
+        """Three different genre families → three playlists."""
+        result = classify_track_multi("electronic, hip hop, chill")
+        assert len(result) == 3
+        assert "TURDOM Electronic" in result
+        assert "TURDOM Hip-Hop" in result
+        assert "TURDOM Chill" in result
+
+    def test_unknown_genre_empty(self):
+        assert classify_track_multi("zambian highlife") == []
+
+    def test_empty_string(self):
+        assert classify_track_multi("") == []
+
+    def test_dedup_same_playlist(self):
+        """Multiple tags mapping to same playlist → deduplicated."""
+        result = classify_track_multi("metal, metalcore, djent")
+        assert result == ["TURDOM Metal"]
+
+    def test_progressive_metal_rock(self):
+        """progressive metal + rock → Metal only (hierarchy)."""
+        result = classify_track_multi("progressive metal, alternative metal, rock")
+        assert "TURDOM Metal" in result
+        assert "TURDOM Rock" not in result
+
+    def test_indie_and_rock(self):
+        """Indie + Rock → both (no hierarchy between them)."""
+        result = classify_track_multi("indie, rock")
+        assert "TURDOM Indie" in result
+        assert "TURDOM Rock" in result
+
+
+# ============================================================
+# classify_track backward compat — returns best single match
+# ============================================================
+
+class TestClassifyTrackCompat:
+
+    def test_returns_first(self):
+        """classify_track returns first from sorted list."""
+        result = classify_track("electronic, hip hop")
+        assert result is not None
+
+    def test_none_for_unknown(self):
+        assert classify_track("zambian highlife") is None
+
+    def test_single_genre(self):
+        assert classify_track("rock") == "TURDOM Rock"
+
+
+# ============================================================
+# Hierarchy edge cases
+# ============================================================
+
+class TestHierarchy:
+
+    def test_metal_rock_indie(self):
+        """Metal suppresses Rock but not Indie."""
+        result = classify_track_multi("metal, rock, indie")
+        assert "TURDOM Metal" in result
+        assert "TURDOM Rock" not in result
+        assert "TURDOM Indie" in result
+
+    def test_dnb_electronic_hiphop(self):
+        """DnB suppresses Electronic but not Hip-Hop."""
+        result = classify_track_multi("drum and bass, electronic, hip hop")
+        assert "TURDOM DnB" in result
+        assert "TURDOM Electronic" not in result
+        assert "TURDOM Hip-Hop" in result
+
+    def test_no_hierarchy_between_unrelated(self):
+        """Pop + Chill → both (no hierarchy)."""
+        result = classify_track_multi("pop, chill")
+        assert "TURDOM Pop" in result
+        assert "TURDOM Chill" in result
+
+
+# ============================================================
+# Real-world tag combinations from Last.fm
+# ============================================================
+
+class TestRealWorldTags:
+
+    def test_sleep_token(self):
+        """progressive metal, alternative metal, metal, rock."""
+        result = classify_track_multi("progressive metal, alternative metal, metal, rock")
+        assert "TURDOM Metal" in result
+        assert "TURDOM Rock" not in result  # suppressed by Metal
+
+    def test_queen_bohemian_rhapsody(self):
+        """classic rock, rock."""
+        result = classify_track_multi("classic rock, rock")
+        assert "TURDOM Rock" in result
+
+    def test_electronic_chill_combo(self):
+        """downtempo, electronic, chill."""
+        result = classify_track_multi("downtempo, electronic, chill")
+        assert "TURDOM Chill" in result
+        assert "TURDOM Electronic" in result
+
+    def test_phonk_standalone(self):
+        result = classify_track_multi("phonk")
+        assert result == ["TURDOM Phonk"]


### PR DESCRIPTION
## Summary
- **Multi-genre:** tracks can go to multiple playlists (e.g. Electronic + Hip-Hop)
- **Hierarchy:** Metal > Rock, DnB > Electronic, R&B > Pop (specific suppresses parent)
- **Drop warning:** re-adding a previously dropped track shows warning with history
- **Spotify fallback removed:** only Last.fm + AI for genre resolution
- **Backfill reset:** `/backfill_genres reset` clears all genres and re-resolves

## Key changes
- `classify_track_multi()` — returns all matching playlists
- `distribute_session_tracks` — adds to multiple playlists
- `check_previously_dropped()` — checks session_tracks for drops
- `resolve_genre` returns None (not "unknown") when unresolvable
- `_resolve_lastfm` stores up to 5 classifiable tags

## Test plan
- [x] 24 new tests for multi-genre + hierarchy (363 total)
- [ ] Deploy → `/backfill_genres reset` → analyze results
- [ ] Verify tracks with multiple genres end up in correct playlists
- [ ] Add previously dropped track → warning shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)